### PR TITLE
Updated the s3 signature version from v4 (default) to v2 

### DIFF
--- a/hb-cf-event/index.js
+++ b/hb-cf-event/index.js
@@ -1,7 +1,9 @@
 'use strict'
 var AWS = require('aws-sdk');
 var sns = new AWS.SNS({ region: 'us-east-1' });
-var s3 = new AWS.S3({ region: 'us-east-1' });
+var s3 = new AWS.S3({ 
+    region: 'us-east-1',
+    signatureVersion: 'v2' });
 
 var CONFIG, cfMessage = {};
 

--- a/hb-cf-github-commit/index.js
+++ b/hb-cf-github-commit/index.js
@@ -1,7 +1,9 @@
 'use strict'
 var AWS = require('aws-sdk');
 var sns = new AWS.SNS({ region: 'us-east-1' });
-var s3 = new AWS.S3({ region: 'us-east-1' });
+var s3 = new AWS.S3({ 
+    region: 'us-east-1',
+    signatureVersion: 'v2' });
 
 var CONFIG, githubEvent;
 


### PR DESCRIPTION
for the gitub commit event and the cloud formation stack completion event. Seems like v4 signature does not work for the s3.getObject call